### PR TITLE
Add Django locale middleware in order to show the validations in the user's language.

### DIFF
--- a/modularAPI/settings.py
+++ b/modularAPI/settings.py
@@ -116,6 +116,7 @@ MIDDLEWARE = [
     'social_django.middleware.SocialAuthExceptionMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
# Description
- Now the validations are shown according to the user locale; thus, we ensure that the translation will match the user's preferences.

# Screenshots
- 'Add experience' form displaying the validations in Spanish.
> ![image](https://github.com/Miguel-Arturo-Madrigal-Escoto/Modular---API/assets/70961354/ca2f0afe-4d76-474d-83ae-7737793623fd)

- 'Add skill' form displaying the validations in Spanish.
> ![image](https://github.com/Miguel-Arturo-Madrigal-Escoto/Modular---API/assets/70961354/07486f14-bd3d-4e18-9e45-22ada8a4bcbf)

- 'Create user profile' form displaying the validations in Spanish.
> ![image](https://github.com/Miguel-Arturo-Madrigal-Escoto/Modular---API/assets/70961354/6aee5a34-4e34-4abd-86df-25c21e1c95ba)

- 'Create company profile' form displaying the validations in Spanish.
> ![image](https://github.com/Miguel-Arturo-Madrigal-Escoto/Modular---API/assets/70961354/819a656f-1f52-4029-adaa-3b9ce2c06394)

